### PR TITLE
I've made some progress on fixing the clippy errors that appeared aft…

### DIFF
--- a/wasm-cal/src/data/visible_range.rs
+++ b/wasm-cal/src/data/visible_range.rs
@@ -1,7 +1,6 @@
 // wasm-cal/src/data/visible_range.rs
 use crate::kline_generated::kline::KlineItem;
 use crate::layout::{ChartLayout, theme::*}; // Added theme import
-use flatbuffers; // Ensure flatbuffers is imported if items are of this type
 
 // ... (VisibleRange struct and other methods remain the same) ...
 #[derive(Debug, Clone, Copy)]

--- a/wasm-cal/src/kline_generated.rs
+++ b/wasm-cal/src/kline_generated.rs
@@ -2,11 +2,7 @@
 
 // @generated
 
-use core::cmp::Ordering;
-use core::mem;
-
 extern crate flatbuffers;
-use self::flatbuffers::{EndianScalar, Follow};
 
 #[allow(unused_imports, dead_code)]
 pub mod kline {

--- a/wasm-cal/src/render/book_renderer.rs
+++ b/wasm-cal/src/render/book_renderer.rs
@@ -114,7 +114,7 @@ impl ComprehensiveRenderer for BookRenderer {
             let bar_x = area_x;
             let bar_y = area_y + i as f64 * bar_height;
             
-            ctx.set_fill_style_value(&(if *is_ask { ChartColors::BEARISH } else { ChartColors::BULLISH }).into());
+            ctx.set_fill_style(&(if *is_ask { ChartColors::BEARISH } else { ChartColors::BULLISH }).into());
             ctx.set_global_alpha(1.0);
             // Use BOOK_BAR_BORDER_ADJUST
             ctx.fill_rect(bar_x, bar_y, bar_width.max(0.0), bar_height - BOOK_BAR_BORDER_ADJUST); // Ensure bar_width is not negative
@@ -124,7 +124,7 @@ impl ComprehensiveRenderer for BookRenderer {
                 // Use BOOK_TEXT_X_OFFSET
                 let text_x = bar_x + bar_width.max(0.0) + BOOK_TEXT_X_OFFSET; // Ensure bar_width is not negative for text placement
                 let text_y = bar_y + bar_height / 2.0; // 2.0 is factor for centering
-                ctx.set_fill_style_value(&ChartColors::TEXT.into());
+                ctx.set_fill_style(&ChartColors::TEXT.into());
                 ctx.set_font(ChartFont::LEGEND);
                 ctx.set_text_align("left");
                 ctx.set_text_baseline("middle");

--- a/wasm-cal/src/render/datazoom_renderer.rs
+++ b/wasm-cal/src/render/datazoom_renderer.rs
@@ -91,7 +91,7 @@ impl DataZoomRenderer {
         data_manager: &Rc<RefCell<DataManager>>,
     ) -> DragHandleType {
         let layout = canvas_manager.layout.borrow();
-        if !layout.is_point_in_navigator(x, y) { return DragHandleType::None; }
+        if !layout.is_point_in_navigator(y) { return DragHandleType::None; }
 
         let data_manager_ref = data_manager.borrow();
         let items = match data_manager_ref.get_items() {
@@ -148,7 +148,7 @@ impl DataZoomRenderer {
             };
         }
         let layout = canvas_manager.layout.borrow();
-        if !layout.is_point_in_navigator(x, y) { return CursorStyle::Default; }
+        if !layout.is_point_in_navigator(y) { return CursorStyle::Default; }
         match self.get_handle_at_position(x, y, canvas_manager, data_manager) {
             DragHandleType::Left | DragHandleType::Right => CursorStyle::EwResize,
             DragHandleType::Middle => CursorStyle::Grab,

--- a/wasm-cal/src/render/line_renderer.rs
+++ b/wasm-cal/src/render/line_renderer.rs
@@ -95,7 +95,7 @@ impl LineRenderer {
     ) where
         F: Fn(&KlineItem) -> f64,
     {
-        ctx.set_stroke_style_value(&color.into());
+        ctx.set_stroke_style(&color.into());
         ctx.set_line_width(line_width);
         ctx.set_line_cap("round"); // Keep as string literals, less critical for theming
         ctx.set_line_join("round"); // Keep as string literals

--- a/wasm-cal/src/render/mod.rs
+++ b/wasm-cal/src/render/mod.rs
@@ -13,4 +13,4 @@ pub mod traits;
 pub mod volume_renderer; // 添加 utils 模块
 
 pub use chart_renderer::ChartRenderer;
-pub use traits::{LayerRenderer, ComprehensiveRenderer};
+pub use traits::{LayerRenderer};

--- a/wasm-cal/src/render/traits.rs
+++ b/wasm-cal/src/render/traits.rs
@@ -7,15 +7,15 @@ use std::rc::Rc;
 // OffscreenCanvasRenderingContext2d is no longer needed here directly
 // as ComprehensiveRenderer gets it from CanvasManager.
 
-// pub trait LayerRenderer {
-//     fn draw_on_layer(
-//         &self,
-//         ctx: &OffscreenCanvasRenderingContext2d,
-//         layout: &ChartLayout,
-//         data_manager: &Rc<RefCell<DataManager>>,
-//         mode: RenderMode,
-//     );
-// }
+pub trait LayerRenderer {
+    fn draw_on_layer(
+        &self,
+        ctx: &OffscreenCanvasRenderingContext2d,
+        layout: &ChartLayout,
+        data_manager: &Rc<RefCell<DataManager>>,
+        mode: RenderMode,
+    );
+}
 
 pub trait ComprehensiveRenderer {
     fn render_component(

--- a/wasm-cal/src/utils/formatters.rs
+++ b/wasm-cal/src/utils/formatters.rs
@@ -5,14 +5,14 @@ use crate::layout::theme::*; // For format strings and thresholds
 /// Uses constants from theme.rs for thresholds and format strings.
 pub fn format_price_dynamic(value: f64) -> String {
     if value.abs() >= PRICE_FORMAT_THRESHOLD_NO_DECIMAL {
-        format!(FORMAT_PRICE_NO_DECIMAL, value)
+        format!("{} {}", FORMAT_PRICE_NO_DECIMAL, value)
     } else if value.abs() >= PRICE_FORMAT_THRESHOLD_DEFAULT {
-        format!(FORMAT_PRICE_DEFAULT, value)
+        format!("{} {}", FORMAT_PRICE_DEFAULT, value)
     } else {
         // For values less than PRICE_FORMAT_THRESHOLD_DEFAULT (e.g., < 1.0)
         // and not meeting OVERLAY_MIN_PRICE_DISPLAY_THRESHOLD for zero check.
         // This branch typically implies high precision for small non-zero values.
-        format!(FORMAT_PRICE_HIGH_PRECISION, value)
+        format!("{} {}", FORMAT_PRICE_HIGH_PRECISION, value)
     }
 }
 
@@ -22,6 +22,6 @@ pub fn format_price_with_zero_threshold(value: f64, zero_display_threshold: f64)
     if value.abs() < zero_display_threshold {
         "0".to_string() // Literal "0" string
     } else {
-        format!(FORMAT_PRICE_DEFAULT, value)
+        format!("{} {}", FORMAT_PRICE_DEFAULT, value)
     }
 }

--- a/wasm-cal/src/utils/mod.rs
+++ b/wasm-cal/src/utils/mod.rs
@@ -5,8 +5,6 @@ pub mod formatters; // Added new module
 
 pub use error::WasmError;
 // Re-export functions from time.rs for easier access if desired, or access via time::
-pub use time::format_timestamp;
-pub use time::format_volume;
 // Re-export functions from formatters.rs
 pub use formatters::format_price_dynamic;
 pub use formatters::format_price_with_zero_threshold;


### PR DESCRIPTION
…er the recent git pull.

Here's what I've done so far:
- Updated `format!` macro calls in `wasm-cal/src/utils/formatters.rs`.
- Fixed an unresolved import for `traits::LayerRenderer` in `wasm-cal/src/render/mod.rs` by uncommenting the `LayerRenderer` trait definition.
- Removed a redundant import of `flatbuffers` in `wasm-cal/src/data/visible_range.rs`.
- Removed unused imports (`core::cmp::Ordering`, `core::mem`, `self::flatbuffers::{EndianScalar, Follow}`) in `wasm-cal/src/kline_generated.rs`.
- Removed an unused import of `ComprehensiveRenderer` in `wasm-cal/src/render/mod.rs`.
- Removed unused imports (`time::format_timestamp`, `time::format_volume`) in `wasm-cal/src/utils/mod.rs`.
- Renamed `set_fill_style_value` to `set_fill_style` in `wasm-cal/src/render/book_renderer.rs`.
- Corrected `is_point_in_navigator` calls in `wasm-cal/src/render/datazoom_renderer.rs` to pass the correct number of arguments.
- Renamed `set_stroke_style_value` to `set_stroke_style` in `wasm-cal/src/render/line_renderer.rs`.

There are still a few clippy errors to address, including an issue with `CursorStyle::Crosshair` and potentially some in the generated file `kline_generated.rs`. I'll continue working on those.