### PR TITLE
Fix remaining clippy warnings and errors

### DIFF
--- a/wasm-cal/src/kline_generated.rs
+++ b/wasm-cal/src/kline_generated.rs
@@ -25,7 +25,7 @@ pub mod kline {
         #[inline]
         unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
             Self {
-                _tab: flatbuffers::Table::new(buf, loc),
+                _tab: unsafe { flatbuffers::Table::new(buf, loc) },
             }
         }
     }
@@ -158,7 +158,7 @@ pub mod kline {
         #[inline]
         unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
             Self {
-                _tab: flatbuffers::Table::new(buf, loc),
+                _tab: unsafe { flatbuffers::Table::new(buf, loc) },
             }
         }
     }
@@ -487,7 +487,7 @@ pub mod kline {
         #[inline]
         unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
             Self {
-                _tab: flatbuffers::Table::new(buf, loc),
+                _tab: unsafe { flatbuffers::Table::new(buf, loc) },
             }
         }
     }
@@ -671,14 +671,14 @@ pub mod kline {
     /// # Safety
     /// Callers must trust the given bytes do indeed contain a valid `KlineData`.
     pub unsafe fn root_as_kline_data_unchecked(buf: &[u8]) -> KlineData {
-        flatbuffers::root_unchecked::<KlineData>(buf)
+        unsafe { flatbuffers::root_unchecked::<KlineData>(buf) }
     }
     #[inline]
     /// Assumes, without verification, that a buffer of bytes contains a size prefixed KlineData and returns it.
     /// # Safety
     /// Callers must trust the given bytes do indeed contain a valid size prefixed `KlineData`.
     pub unsafe fn size_prefixed_root_as_kline_data_unchecked(buf: &[u8]) -> KlineData {
-        flatbuffers::size_prefixed_root_unchecked::<KlineData>(buf)
+        unsafe { flatbuffers::size_prefixed_root_unchecked::<KlineData>(buf) }
     }
     pub const KLINE_DATA_IDENTIFIER: &str = "KLI1";
 

--- a/wasm-cal/src/render/book_renderer.rs
+++ b/wasm-cal/src/render/book_renderer.rs
@@ -64,8 +64,8 @@ impl ComprehensiveRenderer for BookRenderer {
         }
 
 
-        let last_mode_val = self.last_mode.get();
-        let last_idx_val = self.last_idx.get();
+        let _last_mode_val = self.last_mode.get();
+        let _last_idx_val = self.last_idx.get();
         // The check `last_mode_val != Some(mode) || last_idx_val != Some(idx)` was commented out.
         // If it's meant to be active, it should be here.
         // For now, assuming it always redraws if called.
@@ -114,7 +114,7 @@ impl ComprehensiveRenderer for BookRenderer {
             let bar_x = area_x;
             let bar_y = area_y + i as f64 * bar_height;
             
-            ctx.set_fill_style(&(if *is_ask { ChartColors::BEARISH } else { ChartColors::BULLISH }).into());
+            ctx.set_fill_style_js_value(&(if *is_ask { ChartColors::BEARISH } else { ChartColors::BULLISH }).into());
             ctx.set_global_alpha(1.0);
             // Use BOOK_BAR_BORDER_ADJUST
             ctx.fill_rect(bar_x, bar_y, bar_width.max(0.0), bar_height - BOOK_BAR_BORDER_ADJUST); // Ensure bar_width is not negative
@@ -124,7 +124,7 @@ impl ComprehensiveRenderer for BookRenderer {
                 // Use BOOK_TEXT_X_OFFSET
                 let text_x = bar_x + bar_width.max(0.0) + BOOK_TEXT_X_OFFSET; // Ensure bar_width is not negative for text placement
                 let text_y = bar_y + bar_height / 2.0; // 2.0 is factor for centering
-                ctx.set_fill_style(&ChartColors::TEXT.into());
+                ctx.set_fill_style_js_value(&ChartColors::TEXT.into());
                 ctx.set_font(ChartFont::LEGEND);
                 ctx.set_text_align("left");
                 ctx.set_text_baseline("middle");

--- a/wasm-cal/src/render/cursor_style.rs
+++ b/wasm-cal/src/render/cursor_style.rs
@@ -26,6 +26,8 @@ pub enum CursorStyle {
     Help,
     /// 不允许样式
     NotAllowed,
+    /// 十字准线样式
+    Crosshair,
 }
 
 impl fmt::Display for CursorStyle {
@@ -49,6 +51,7 @@ impl CursorStyle {
             CursorStyle::Wait => "wait",
             CursorStyle::Help => "help",
             CursorStyle::NotAllowed => "not-allowed",
+            CursorStyle::Crosshair => "crosshair",
         }
     }
 }

--- a/wasm-cal/src/render/datazoom_renderer.rs
+++ b/wasm-cal/src/render/datazoom_renderer.rs
@@ -100,7 +100,7 @@ impl DataZoomRenderer {
         };
         if items.is_empty() { return DragHandleType::None; }
 
-        let (visible_start, visible_count, _) = data_manager_ref.get_visible_range().get_range();
+        let (_visible_start, _visible_count, _) = data_manager_ref.get_visible_range().get_range();
         // ChartLayout should have a method to get these coordinates based on its state
         // For now, assuming VisibleRange has a method or ChartLayout can compute this
         let (visible_start_x, visible_end_x) = data_manager_ref.get_visible_range().get_screen_coordinates(&layout);

--- a/wasm-cal/src/render/line_renderer.rs
+++ b/wasm-cal/src/render/line_renderer.rs
@@ -95,7 +95,7 @@ impl LineRenderer {
     ) where
         F: Fn(&KlineItem) -> f64,
     {
-        ctx.set_stroke_style(&color.into());
+        ctx.set_stroke_style_js_value(&color.into());
         ctx.set_line_width(line_width);
         ctx.set_line_cap("round"); // Keep as string literals, less critical for theming
         ctx.set_line_join("round"); // Keep as string literals

--- a/wasm-cal/src/render/mod.rs
+++ b/wasm-cal/src/render/mod.rs
@@ -13,4 +13,3 @@ pub mod traits;
 pub mod volume_renderer; // 添加 utils 模块
 
 pub use chart_renderer::ChartRenderer;
-pub use traits::{LayerRenderer};

--- a/wasm-cal/src/render/price_renderer.rs
+++ b/wasm-cal/src/render/price_renderer.rs
@@ -78,7 +78,7 @@ impl ComprehensiveRenderer for PriceRenderer {
 
         if !bullish_high_low_lines.is_empty() {
             ctx.begin_path();
-            ctx.set_stroke_style_value(&ChartColors::BULLISH.into());
+            ctx.set_stroke_style_js_value(&ChartColors::BULLISH.into());
             ctx.set_line_width(PRICE_WICK_LINE_WIDTH); // Use constant
             let empty_array = js_sys::Float64Array::new_with_length(0);
             ctx.set_line_dash(&empty_array).unwrap();
@@ -91,7 +91,7 @@ impl ComprehensiveRenderer for PriceRenderer {
 
         if !bearish_high_low_lines.is_empty() {
             ctx.begin_path();
-            ctx.set_stroke_style_value(&ChartColors::BEARISH.into());
+            ctx.set_stroke_style_js_value(&ChartColors::BEARISH.into());
             ctx.set_line_width(PRICE_WICK_LINE_WIDTH); // Use constant
             let empty_array = js_sys::Float64Array::new_with_length(0);
             ctx.set_line_dash(&empty_array).unwrap();
@@ -103,7 +103,7 @@ impl ComprehensiveRenderer for PriceRenderer {
         }
 
         if !bullish_rects.is_empty() {
-            ctx.set_fill_style_value(&ChartColors::BULLISH.into());
+            ctx.set_fill_style_js_value(&ChartColors::BULLISH.into());
             ctx.begin_path();
             for (x, y, width, height) in bullish_rects {
                 ctx.rect(x, y, width, height);
@@ -112,7 +112,7 @@ impl ComprehensiveRenderer for PriceRenderer {
         }
 
         if !bearish_rects.is_empty() {
-            ctx.set_fill_style_value(&ChartColors::BEARISH.into());
+            ctx.set_fill_style_js_value(&ChartColors::BEARISH.into());
             ctx.begin_path();
             for (x, y, width, height) in bearish_rects {
                 ctx.rect(x, y, width, height);

--- a/wasm-cal/src/render/traits.rs
+++ b/wasm-cal/src/render/traits.rs
@@ -1,6 +1,7 @@
 use crate::canvas::CanvasManager;
 use crate::data::DataManager;
 use crate::layout::ChartLayout;
+use web_sys::OffscreenCanvasRenderingContext2d;
 use crate::render::chart_renderer::RenderMode;
 use std::cell::RefCell;
 use std::rc::Rc;


### PR DESCRIPTION
This commit addresses a second round of clippy warnings and errors identified from your feedback.

Changes include:
- Added missing `Crosshair` variant to `CursorStyle` enum and its CSS mapping.
- Imported `OffscreenCanvasRenderingContext2d` in `render/traits.rs`.
- Replaced deprecated `set_fill_style` and `set_stroke_style` calls with assumed `_js_value` suffixed versions in `book_renderer.rs` and `line_renderer.rs`.
- Corrected method not found errors in `price_renderer.rs` by replacing `_value` suffixed methods with assumed `_js_value` versions.
- Prefixed unused variables in `book_renderer.rs` and `datazoom_renderer.rs` with underscores.
- Wrapped unsafe flatbuffer calls in `kline_generated.rs` in unsafe blocks.

Verification with `cargo clippy` could not be performed in my current environment. The changes for deprecated canvas methods are based on assumed API updates and may require further review.