### PR TITLE
Fix: Correct canvas rendering method names

### DIFF
--- a/wasm-cal/src/render/book_renderer.rs
+++ b/wasm-cal/src/render/book_renderer.rs
@@ -114,7 +114,7 @@ impl ComprehensiveRenderer for BookRenderer {
             let bar_x = area_x;
             let bar_y = area_y + i as f64 * bar_height;
             
-            ctx.set_fill_style_js_value(&(if *is_ask { ChartColors::BEARISH } else { ChartColors::BULLISH }).into());
+            ctx.set_fill_style(&(if *is_ask { ChartColors::BEARISH } else { ChartColors::BULLISH }).into());
             ctx.set_global_alpha(1.0);
             // Use BOOK_BAR_BORDER_ADJUST
             ctx.fill_rect(bar_x, bar_y, bar_width.max(0.0), bar_height - BOOK_BAR_BORDER_ADJUST); // Ensure bar_width is not negative
@@ -124,7 +124,7 @@ impl ComprehensiveRenderer for BookRenderer {
                 // Use BOOK_TEXT_X_OFFSET
                 let text_x = bar_x + bar_width.max(0.0) + BOOK_TEXT_X_OFFSET; // Ensure bar_width is not negative for text placement
                 let text_y = bar_y + bar_height / 2.0; // 2.0 is factor for centering
-                ctx.set_fill_style_js_value(&ChartColors::TEXT.into());
+                ctx.set_fill_style(&ChartColors::TEXT.into());
                 ctx.set_font(ChartFont::LEGEND);
                 ctx.set_text_align("left");
                 ctx.set_text_baseline("middle");

--- a/wasm-cal/src/render/line_renderer.rs
+++ b/wasm-cal/src/render/line_renderer.rs
@@ -95,7 +95,7 @@ impl LineRenderer {
     ) where
         F: Fn(&KlineItem) -> f64,
     {
-        ctx.set_stroke_style_js_value(&color.into());
+        ctx.set_stroke_style(&color.into());
         ctx.set_line_width(line_width);
         ctx.set_line_cap("round"); // Keep as string literals, less critical for theming
         ctx.set_line_join("round"); // Keep as string literals

--- a/wasm-cal/src/render/price_renderer.rs
+++ b/wasm-cal/src/render/price_renderer.rs
@@ -78,7 +78,7 @@ impl ComprehensiveRenderer for PriceRenderer {
 
         if !bullish_high_low_lines.is_empty() {
             ctx.begin_path();
-            ctx.set_stroke_style_js_value(&ChartColors::BULLISH.into());
+            ctx.set_stroke_style(&ChartColors::BULLISH.into());
             ctx.set_line_width(PRICE_WICK_LINE_WIDTH); // Use constant
             let empty_array = js_sys::Float64Array::new_with_length(0);
             ctx.set_line_dash(&empty_array).unwrap();
@@ -91,7 +91,7 @@ impl ComprehensiveRenderer for PriceRenderer {
 
         if !bearish_high_low_lines.is_empty() {
             ctx.begin_path();
-            ctx.set_stroke_style_js_value(&ChartColors::BEARISH.into());
+            ctx.set_stroke_style(&ChartColors::BEARISH.into());
             ctx.set_line_width(PRICE_WICK_LINE_WIDTH); // Use constant
             let empty_array = js_sys::Float64Array::new_with_length(0);
             ctx.set_line_dash(&empty_array).unwrap();
@@ -103,7 +103,7 @@ impl ComprehensiveRenderer for PriceRenderer {
         }
 
         if !bullish_rects.is_empty() {
-            ctx.set_fill_style_js_value(&ChartColors::BULLISH.into());
+            ctx.set_fill_style(&ChartColors::BULLISH.into());
             ctx.begin_path();
             for (x, y, width, height) in bullish_rects {
                 ctx.rect(x, y, width, height);
@@ -112,7 +112,7 @@ impl ComprehensiveRenderer for PriceRenderer {
         }
 
         if !bearish_rects.is_empty() {
-            ctx.set_fill_style_js_value(&ChartColors::BEARISH.into());
+            ctx.set_fill_style(&ChartColors::BEARISH.into());
             ctx.begin_path();
             for (x, y, width, height) in bearish_rects {
                 ctx.rect(x, y, width, height);


### PR DESCRIPTION
I replaced incorrect `set_fill_style_js_value` and `set_stroke_style_js_value` method calls with the correct `set_fill_style` and `set_stroke_style` respectively in the following files:
- wasm-cal/src/render/book_renderer.rs
- wasm-cal/src/render/line_renderer.rs
- wasm-cal/src/render/price_renderer.rs

This resolves compilation errors E0599.

Note: Build verification for the wasm-cal project was skipped due to the unavailability of the wasm32-unknown-unknown Rust target and the inability to install it in the current build environment.