### PR TITLE
Refactor: Optimize permission type handling

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -228,11 +228,21 @@ enum PermissionType {
   DATA // 数据权限
 }
 
+enum HttpMethod {
+  GET
+  POST
+  PUT
+  DELETE
+  PATCH
+  OPTIONS
+  HEAD
+}
+
 // API权限详细信息表
 model ApiPermission {
   id           String @id @default(cuid())
   permissionId String @unique
-  httpMethod   String // HTTP方法 (GET, POST, PUT, DELETE等)
+  httpMethod   HttpMethod // HTTP方法 (GET, POST, PUT, DELETE等)
   endpoint     String // API端点路径
   rateLimit    Int? // 速率限制 (每分钟请求数)
 

--- a/schemas/permissionSchemas.ts
+++ b/schemas/permissionSchemas.ts
@@ -1,0 +1,21 @@
+import { PermissionType, HttpMethod } from '@prisma/client';
+import { z } from 'zod';
+
+export const PermissionTypeEnum = z.nativeEnum(PermissionType);
+export const HttpMethodEnum = z.nativeEnum(HttpMethod);
+
+export const ApiPermissionDetailsSchema = z.object({
+  httpMethod: HttpMethodEnum,
+  endpoint: z.string().min(1, 'Endpoint is required').max(255),
+  rateLimit: z.number().int().positive().optional(),
+});
+
+export const MenuPermissionDetailsSchema = z.object({
+  menuId: z.string().min(1, 'Menu ID is required').max(100),
+});
+
+export const DataPermissionDetailsSchema = z.object({
+  tableName: z.string().min(1, 'Table name is required').max(100),
+  columnName: z.string().min(1, 'Column name is required').max(100).optional(),
+  conditions: z.string().max(1000).optional(),
+});


### PR DESCRIPTION
This commit introduces several improvements to the permission handling logic:

1.  **Added `HttpMethod` Enum to Prisma Schema**:
    *   Defined an `HttpMethod` enum (`GET`, `POST`, `PUT`, `DELETE`, `PATCH`, `OPTIONS`, `HEAD`) in `prisma/schema.prisma`.
    *   The `ApiPermission` model's `httpMethod` field now uses this enum instead of `String`, enhancing type safety and data integrity.
    *   The Prisma client has been regenerated to reflect these changes.

2.  **Centralized Permission Zod Schemas**:
    *   Common Zod schemas related to permission types and details (`PermissionTypeEnum`, `HttpMethodEnum`, `ApiPermissionDetailsSchema`, `MenuPermissionDetailsSchema`, `DataPermissionDetailsSchema`) have been moved to a new central file: `schemas/permissionSchemas.ts`.
    *   The API route files (`app/api/permissions/route.ts` and `app/api/permissions/[permissionId]/route.ts`) now import these schemas, reducing code duplication and improving maintainability.

3.  **Linting Fixes**:
    *   Addressed linting errors (unused variables, imports, and typing issues) in `app/api/permissions/route.ts` and `app/api/permissions/[permissionId]/route.ts` that arose from or were identified after the refactoring.